### PR TITLE
Don't Reapeat Yourself

### DIFF
--- a/src/main/java/fr/catcore/modremapperapi/api/RemapLibrary.java
+++ b/src/main/java/fr/catcore/modremapperapi/api/RemapLibrary.java
@@ -1,6 +1,7 @@
 package fr.catcore.modremapperapi.api;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 
 public class RemapLibrary {
@@ -20,6 +21,13 @@ public class RemapLibrary {
         this.url = "";
         this.path = path;
         this.toExclude = toExclude;
+        this.fileName = fileName;
+    }
+
+    public RemapLibrary(Path path, String fileName) {
+        this.url = "";
+        this.path = path;
+        this.toExclude = new ArrayList<>();
         this.fileName = fileName;
     }
 }


### PR DESCRIPTION
Adds a constructor that doesn't take a list to RemapLibrary, in case you don't want to exclude anything. Putting `new ArrayList<>()` on every line gets quite repetitive.